### PR TITLE
Fixing the progress overflow.

### DIFF
--- a/src/main/scala/S3Plugin.scala
+++ b/src/main/scala/S3Plugin.scala
@@ -195,7 +195,9 @@ object S3Plugin extends sbt.Plugin {
         n
     }
     def progressChanged(progressEvent:ProgressEvent) {
-      uploadedBytes=uploadedBytes+progressEvent.getBytesTransfered()
+      if(progressEvent.getEventCode() == ProgressEvent.PART_COMPLETED_EVENT_CODE) {
+        uploadedBytes=uploadedBytes+progressEvent.getBytesTransfered()
+      }
       print(progressBar(if (fileSize>0) ((uploadedBytes*100)/fileSize).toInt else 100))
       print(fileName)
       if (progressEvent.getEventCode() == ProgressEvent.COMPLETED_EVENT_CODE)


### PR DESCRIPTION
We ran in to a issue where the progress bar char buffer overflowed and we think its bcs one of the parts of the upload failed and retry happened but the failed part was added to `uploadedBytes` count.  I think this should fix this issue.  Here is the exception we are seeing:

`WARNING: Unable to cleanly close input stream: String index out of range: 51 
java.lang.StringIndexOutOfBoundsException: String index out of range: 51 
at java.lang.String.substring(String.java:1907) 
at com.typesafe.sbt.S3Plugin$.com$typesafe$sbt$S3Plugin$$progressBar(S3Plugin.scala:174) 
at com.typesafe.sbt.S3Plugin$$anon$1.progressChanged(S3Plugin.scala:200) 
at com.amazonaws.services.s3.internal.ProgressReportingInputStream.close(ProgressReportingInputStream.java:102`
