### PR TITLE
metadata in upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 *.class
 *.log
 
+# make specific
+sbtexists
+
 # sbt specific
 dist/*
 target/
@@ -8,7 +11,15 @@ lib_managed/
 src_managed/
 project/boot/
 project/plugins/project/
-project/target/
 
 # Scala-IDE specific
 .scala_dependencies
+
+# Intellij specific cruft
+.idea
+*.iws
+.history
+.idea_modules
+gen
+out
+tmp

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ All these operations will use HTTPS as a transport protocol.
 Please check the Scaladoc API of the `S3Plugin` object, and of its nested `S3` object,
 to get additional documentation of the available sbt tasks.
 
-## Example
+## Example 1
 
 Here is a complete example:
 
@@ -56,3 +56,33 @@ You can also see progress while uploading:
     > s3-upload
     [==================================================]   100%   zipa.txt
     [=====================================>            ]    74%   zipb.jar
+
+## Example 2
+
+As well as simply uploading a file to s3 you can also set some s3 ObjectMetadata.
+For example, you may want to gzip a CSS file for quicker download but still have it's content type as css,
+In which case you need to set the Content-Type and Content-Encoding, a small change to
+build.sbt is all that is needed.
+
+build.sbt:
+
+    import S3._
+
+    s3Settings
+
+    Seq((target.value / "web" / "stage" / "css" / "style-group2.css.gz" ,"css/style-group2.css"))
+
+    val md = {
+      import com.amazonaws.services.s3.model.ObjectMetadata
+      var omd = new ObjectMetadata()
+      omd.setContentEncoding("gzip")
+      omd.setContentType("text/css")
+      omd
+    }
+
+    metadata in upload := Map("css/style-group2.css" -> md)
+
+    host in upload := "s3sbt-test.s3.amazonaws.com"
+
+    credentials += Credentials(Path.userHome / ".s3credentials")
+

--- a/src/main/scala/S3Plugin.scala
+++ b/src/main/scala/S3Plugin.scala
@@ -55,6 +55,7 @@ import org.apache.commons.lang.StringUtils.removeEndIgnoreCase
   */
 object S3Plugin extends sbt.Plugin {
 
+  type MetadataMap = Map[String, ObjectMetadata]
   /**
     * This nested object defines the sbt keys made available by the S3Plugin: read here for tasks info.
     */
@@ -132,6 +133,7 @@ object S3Plugin extends sbt.Plugin {
     */
     val progress=SettingKey[Boolean]("s3-progress","Set to true to get a progress indicator during S3 uploads/downloads (default false).")
 
+    val metadata=SettingKey[MetadataMap]("s3-metadata","Sequence of Toples of S3 keys (paths) on which to apply the metadata")
   }
 
   import S3._
@@ -149,9 +151,24 @@ object S3Plugin extends sbt.Plugin {
   }
   private def getBucket(host:String) = removeEndIgnoreCase(host,".s3.amazonaws.com")
 
-  private def s3InitTask[Item](thisTask:TaskKey[Unit], itemsKey:TaskKey[Seq[Item]],
-                               op:(AmazonS3Client,Bucket,Item,Boolean)=>Unit,
+  private def s3InitUploadTask[Item](thisTask:TaskKey[Unit], itemsKey:TaskKey[Seq[Item]], metadataKey:SettingKey[MetadataMap],
+                               op:(AmazonS3Client,Bucket,Item,MetadataMap,Boolean)=>Unit,
                                msg:(Bucket,Item)=>String, lastMsg:(Bucket,Seq[Item])=>String )  =
+
+    (credentials in thisTask, itemsKey in thisTask, host in thisTask, progress in thisTask, streams, metadataKey in thisTask) map {
+      (creds,items,host,progress,streams, metadata) =>
+        val client = getClient(creds, host)
+        val bucket = getBucket(host)
+        items foreach { item =>
+          streams.log.debug(msg(bucket,item))
+          op(client,bucket,item, metadata, progress)
+        }
+        streams.log.info(lastMsg(bucket,items))
+    }
+
+  private def s3InitTask[Item](thisTask:TaskKey[Unit], itemsKey:TaskKey[Seq[Item]],
+                                     op:(AmazonS3Client,Bucket,Item,Boolean)=>Unit,
+                                     msg:(Bucket,Item)=>String, lastMsg:(Bucket,Seq[Item])=>String )  =
 
     (credentials in thisTask, itemsKey in thisTask, host in thisTask, progress in thisTask, streams) map {
       (creds,items,host,progress,streams) =>
@@ -159,7 +176,7 @@ object S3Plugin extends sbt.Plugin {
         val bucket = getBucket(host)
         items foreach { item =>
           streams.log.debug(msg(bucket,item))
-          op(client,bucket,item,progress)
+          op(client,bucket,item, progress)
         }
         streams.log.info(lastMsg(bucket,items))
     }
@@ -210,11 +227,14 @@ object S3Plugin extends sbt.Plugin {
    */
   val s3Settings = Seq(
 
-    upload <<= s3InitTask[(File,String)](upload, mappings,
-                           { case (client,bucket,(file,key),progress) =>
+    upload <<= s3InitUploadTask[(File,String)](upload, mappings, metadata,
+                           { case (client,bucket,(file,key),metadataMap,progress) =>
+                               val mdo = metadataMap.get(key)
                                val request=new PutObjectRequest(bucket,key,file)
                                if (progress) addProgressListener(request,file.length(),key)
-                               client.putObject(request)
+                               if (mdo.isDefined) {
+                                 client.putObject(request.withMetadata(mdo.get))
+                               } else client.putObject(request)
                            },
                            { case (bucket,(file,key)) =>  "Uploading "+file.getAbsolutePath()+" as "+key+" into "+bucket },
                            {      (bucket,mapps) =>       "Uploaded "+mapps.length+" files to the S3 bucket \""+bucket+"\"." }
@@ -239,6 +259,7 @@ object S3Plugin extends sbt.Plugin {
 
     host := "",
     keys := Seq(),
+    metadata := Map(),
     mappings in download := Seq(),
     mappings in upload := Seq(),
     progress := false


### PR DESCRIPTION
Hi,
This pull request adds the ability to augment the s3-upload with s3 ObjectMetadata.
This allows users to upload a gzip'd file and set the Content-Encoding to gzip and allow it to be served compressed to the browser.
Please see the example2 in the README.md

Cheers
Karl