### PR TITLE
Use Default aws credentials chain for configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,5 +57,9 @@ You can also see progress while uploading:
     [==================================================]   100%   zipa.txt
     [=====================================>            ]    74%   zipb.jar
 
-If running under EC2, the credentials will be automatically obtained via IAM, unless
-explicitly provided as described above.
+Unless explicitly provided as described above, credentials will be obtained via (in order):
+
+1. `AWS_ACCESS_KEY_ID` and `AWS_SECRET_KEY` environment variables
+2. `aws.accessKeyId` and `aws.secretKey` Java system properties 
+3. Default aws cli credentials file (`~/.aws/credentials`)
+4. IAM instance profile if running under EC2.

--- a/src/main/scala/S3Plugin.scala
+++ b/src/main/scala/S3Plugin.scala
@@ -147,7 +147,7 @@ object S3Plugin extends sbt.Plugin {
       // username -> Access Key Id ; passwd -> Secret Access Key
       case Some(cred) => new BasicAWSCredentials(cred.userName, cred.passwd)
       case None       =>
-        val provider = new InstanceProfileCredentialsProvider
+        val provider = new DefaultAWSCredentialsProviderChain
         try {
           provider.getCredentials()
         } catch {


### PR DESCRIPTION
`DefaultAWSCredentialsProviderChain` chains together multiple default credentials providers and matches on the first to succeed. This way, machines that have the `aws-cli` set up, as well as EC2 instances will have their credentials loaded.

From the [aws javadocs](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html):

> AWS credentials provider chain that looks for credentials in this order:
> * Environment Variables - AWS_ACCESS_KEY_ID and AWS_SECRET_KEY
> * Java System Properties - aws.accessKeyId and aws.secretKey
> * Credential profiles file at the default location (~/.aws/credentials) shared by all AWS SDKs and the AWS CLI
> * Instance profile credentials delivered through the Amazon EC2 metadata service
