### PR TITLE
Fix readme example for metadata use def instead of val

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ build.sbt:
 
     mappings in upload := Seq((target.value / "web" / "stage" / "css" / "style-group2.css.gz" ,"css/style-group2.css"))
 
-    val md = {
+    def md = {
       import com.amazonaws.services.s3.model.ObjectMetadata
       var omd = new ObjectMetadata()
       omd.setContentEncoding("gzip")

--- a/src/main/scala/S3Plugin.scala
+++ b/src/main/scala/S3Plugin.scala
@@ -241,7 +241,7 @@ object S3Plugin extends sbt.Plugin {
                            { case (client,bucket,(file,key),metadata,progress) =>
                                val request=new PutObjectRequest(bucket,key,file)
                                if (progress) addProgressListener(request,file.length(),key)
-                               client.putObject(metadata.get(key).map(request.withMetadata(_)).getOrElse(request))
+                               client.putObject(metadata.get(key).map(request.withMetadata).getOrElse(request))
                                key
                            },
                            { case (bucket,(file,key)) =>  "Uploading "+file.getAbsolutePath()+" as "+key+" into "+bucket },


### PR DESCRIPTION
- Using val causes the ObjectMetadata to be re-used, breaking s3 checksums