### PR TITLE
Adding proxy support to the S3 client

### DIFF
--- a/src/main/scala/S3Plugin.scala
+++ b/src/main/scala/S3Plugin.scala
@@ -152,6 +152,19 @@ object S3Plugin extends sbt.Plugin {
 
   type Bucket=String
 
+  private def makeProxyableClientConfiguration(): ClientConfiguration = {
+    def doWith(prop: String)(f: String => Unit): Unit = {
+      sys.props.get(prop).foreach(f)
+    }
+
+    val config = new ClientConfiguration().withProtocol(Protocol.HTTPS)
+    doWith("http.proxyHost")(config.setProxyHost)
+    doWith("http.proxyPort")(port => config.setProxyPort(port.toInt))
+    doWith("http.proxyUser")(config.setProxyUsername)
+    doWith("http.proxyPassword")(config.setProxyPassword)
+    config
+  }
+
   private def getClient(creds:Seq[Credentials],host:String) = {
     val credentials = Credentials.forHost(creds, host) match {
       // username -> Access Key Id ; passwd -> Secret Access Key
@@ -165,8 +178,9 @@ object S3Plugin extends sbt.Plugin {
             sys.error("Could not find S3 credentials for the host: "+host+", and no IAM credentials available")
         }
     }
-    new AmazonS3Client(credentials, new ClientConfiguration().withProtocol(Protocol.HTTPS))
+    new AmazonS3Client(credentials, makeProxyableClientConfiguration())
   }
+
   private def getBucket(host:String) = removeEndIgnoreCase(host,".s3.amazonaws.com")
 
   private def s3InitTask[Item,Extra,Return](thisTask:TaskKey[Seq[Return]], itemsKey:TaskKey[Seq[Item]],


### PR DESCRIPTION
Since old PR for adding proxy support seems to be stale I took the liberty to implement it myself following Josh's suggestion in the same old PR.

We are using now the fork internally and it works, it would be nice it could be added to an official release.