### PR TITLE
Using my own org for publishing purposes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,9 +6,9 @@ version := "0.10-SNAPSHOT"
 
 isSnapshot := true
 
-organization := "com.github.sbt"
+organization := "cf.janga"
 
-organizationName := "Typesafe"
+organizationName := "Janga"
 
 sbtPlugin := true
 


### PR DESCRIPTION
Given the org was changed from Typesafe, when ownership was transferred to me, I guess I'd rather just use my own org - which I use for other open source projects - for the purposes of publishing artefacts. I've a bintray account and repo and will now be publishing new releases there.